### PR TITLE
add missing key property to links

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -22,7 +22,8 @@ export const onRenderBody = ({
   setHeadComponents(
     pluginOptions.domains.map(domain => React.createElement('link', {
       rel: "preconnect",
-      href: domain
+      href: domain,
+      key: domain
     })));
 
 }


### PR DESCRIPTION
Some packages/modules will complain on missing key properties for the generated links (e.g. react helmet on npm develop does this). This is what the warning looks like:

```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the top-level render call using <head>. See https://fb.me/react-warning-keys for more information.
    in link
    in HTML
```

This commit fixes this issue by adding the domain as key property for each link.