### PR TITLE
Fix React warning when using crossOrigin false

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -17,7 +17,7 @@ export const onRenderBody = ({ setHeadComponents }, pluginOptions) => {
   setHeadComponents(
     parsedDomains.map(({ domain, crossOrigin }) =>
       React.createElement('link', {
-        crossOrigin: crossOrigin,
+        crossOrigin: crossOrigin ? crossOrigin : undefined,
         href: domain,
         key: `${domain}-${crossOrigin}`,
         rel: 'preconnect',


### PR DESCRIPTION
```
Warning: Received `false` for a non-boolean attribute `crossOrigin`.

If you want to write it to the DOM, pass a string instead: crossOrigin="false" or crossOrigin={value.toString()}.

If you used to conditionally omit it with crossOrigin={condition && value}, pass crossOrigin={condition ? value : undefined} instead.
```